### PR TITLE
NEVISACCESSAPP-5436: Don't unmount the Camera View while processing t…

### DIFF
--- a/src/screens/ReadQrCodeScreen.tsx
+++ b/src/screens/ReadQrCodeScreen.tsx
@@ -137,14 +137,20 @@ const ReadQrCodeScreen = () => {
 			<CloseButton onPress={onClose} />
 			<Text style={[styles.textForeground, styles.textTitle]}>{t('readQrCode.title')}</Text>
 			<View style={styles.middleContainer}>
-				{isLoading && <ActivityIndicator size="large" />}
-				{!isLoading && device && hasCameraPermission && (
+				{device && hasCameraPermission && (
 					<Camera
 						style={StyleSheet.absoluteFill}
 						device={device}
 						codeScanner={codeScanner}
 						isActive={isActive}
 					/>
+				)}
+				{isLoading && (
+					<View
+						style={[StyleSheet.absoluteFill, styles.container, styles.middleContainer]}
+					>
+						<ActivityIndicator size="large" />
+					</View>
 				)}
 				{!isLoading && errorMessage && (
 					<Text style={[styles.textForeground, styles.textNormal, styles.textCenter]}>


### PR DESCRIPTION
…he QR code to avoid crashes on Android

- Display the loading indicator over the Camera and not instead on Read QR code screen and only set the Camera to inactive
- Previously both the active state was set to false and the Camera View was removed (unmounted) once isLoading was set to true (while the read QR code is being processed) which seems to cause crashes on Android